### PR TITLE
Added time constant string comparison

### DIFF
--- a/csrf.js
+++ b/csrf.js
@@ -1,6 +1,7 @@
 module.exports = csrf
 
 var crypto = require('crypto')
+var scmp = require('scmp')
 
 // call this with your token, or it'll make a new one.
 function csrf(token) {
@@ -27,7 +28,7 @@ csrf.valid = csrf.validate = function (data, token) {
     return false
 
   // remove the token, so that you don't accidentally save it somewhere.
-  var valid = data['x-csrf-token'] === token
+  var valid = scmp(data['x-csrf-token'], token)
   delete data['x-csrf-token']
   return valid
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "cookies": "~0.3.6",
     "request": "~2.12.0",
     "tap": "^1.2.0"
+  },
+  "dependencies": {
+    "scmp": "~1.0.0"
   }
 }


### PR DESCRIPTION
The string comparison currently used in `csrf-lite` is susceptible to a timing attack (e.g. attacker can detect millisecond changes by Node.js short circuiting string comparison). To mitigate that attack, we can use a time constant string comparison.

In this PR:

- Moved from `===` to `scmp` for time constant string comparison